### PR TITLE
Add UX TwigComponent and UX Toolkit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/translation": "*",
         "symfony/twig-pack": "*",
         "symfony/ux-turbo": "*",
+        "symfony/ux-twig-component": "*",
         "symfony/validator": "*",
         "symfony/web-link": "*"
     },
@@ -35,7 +36,8 @@
         "symfony/debug-pack": "*",
         "symfony/profiler-pack": "*",
         "symfony/maker-bundle": "^1.0",
-        "symfony/test-pack": "*"
+        "symfony/test-pack": "*",
+        "symfony/ux-toolkit": "*"
     },
     "conflict": {
         "symfony/framework-bundle": "<6.3"


### PR DESCRIPTION
When creating a new Symfony Web application, I think it could now make sense to:
- install UX TwigComponent, I think it's something that everyone uses in their Symfony applications, whether legacy or new - it has more than twice UX Turbo installs (already shipped by default since a long time ago)
- install UX Toolkit, which offers ready-to-use Twig components 